### PR TITLE
Added check to prevent empty feed urls from being resolved

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -62,7 +62,9 @@ function isFeedLink (originUrl, base, tagName, attrs) {
     var type = attrs.type || attrs.TYPE;
 
     if (tagName == 'link' && inc(contentTypes, type)) {
+      if (base != null) {
         return url.resolve(originUrl, base ? path.join(base, href) : href);
+      }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed-finder",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stubborn feed auto discovery tool",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This relates to the issue described at https://github.com/cakuki/feed-finder/issues/1