### PR TITLE
Handle empty feed url

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -61,7 +61,7 @@ function isFeedLink (originUrl, base, tagName, attrs) {
     var href = attrs.href || attrs.HREF;
     var type = attrs.type || attrs.TYPE;
 
-    if (tagName == 'link' && inc(contentTypes, type)) {
+    if (href && tagName == 'link' && inc(contentTypes, type)) {
         return url.resolve(originUrl, base ? path.join(base, href) : href);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feed-finder",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Stubborn feed auto discovery tool",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Related to #1 and #2 
If the feed tag like 
```html
<link href="" rel="alternate" title="Title" type="application/atom+xml">
```

then throws an exception like
```
url.js:73
    throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
    ^

TypeError: Parameter 'url' must be a string, not undefined
    at Url.parse (url.js:73:11)
    at urlParse (url.js:67:5)
    at Url.resolve (url.js:621:29)
    at Object.urlResolve [as resolve] (url.js:617:40)
    at isFeedLink (/Users/thomasm/brandwatch/mission-control/node_modules/feed-finder/lib/parser.js:65:20)
    at Object.onOpenTag (/Users/thomasm/brandwatch/mission-control/node_modules/feed-finder/lib/parser.js:39:28)
    at Parser.onopentagend (/Users/thomasm/brandwatch/mission-control/node_modules/htmlparser2/lib/Parser.js:172:37)
    at Tokenizer._stateBeforeAttributeName (/Users/thomasm/brandwatch/mission-control/node_modules/htmlparser2/lib/Tokenizer.js:230:13)
    at Tokenizer._parse (/Users/thomasm/brandwatch/mission-control/node_modules/htmlparser2/lib/Tokenizer.js:658:9)
    at Tokenizer.write (/Users/thomasm/brandwatch/mission-control/node_modules/htmlparser2/lib/Tokenizer.js:632:7)
```
I found this issue when find the feed url on `https://artsy.github.io/`.